### PR TITLE
apply best practice in naming of many to many table and controller

### DIFF
--- a/app/Console/Commands/SeedDataCommand.php
+++ b/app/Console/Commands/SeedDataCommand.php
@@ -106,7 +106,7 @@ class SeedDataCommand extends Command
     private function seedTagsLinks()
     {
         $postsCount = Post::count();
-        DB::statement('Truncate posts_tags');
+        DB::statement('Truncate post_tag');
         $this->info('linking tags');
         $this->output->progressStart($postsCount);
         Post::chunk(
@@ -124,7 +124,7 @@ class SeedDataCommand extends Command
                         }
                     }
                 );
-                DB::table('posts_tags')->insert($links);
+                DB::table('post_tag')->insert($links);
                 $this->output->progressAdvance(1000);
             }
         );

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers;
 use App\Category;
 use Illuminate\Http\Request;
 
-class CategoriesController extends Controller
+class CategoryController extends Controller
 {
     public function index()
     {

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers;
 use App\Post;
 use Illuminate\Http\Request;
 
-class PostsController extends Controller
+class PostController extends Controller
 {
     public function index(){
         $posts = Post::with('user:id,name','category:id,name','tags:tags.id,name')->paginate(50);

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -3,16 +3,15 @@
 namespace App\Http\Controllers;
 
 use App\Tag;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
-class TagsController extends Controller
+class TagController extends Controller
 {
     public function index()
     {
         $tags = Tag::query()
-            ->select('tags.*',DB::raw('COUNT(posts_tags.post_id) as posts_count'))
-            ->leftJoin('posts_tags','posts_tags.tag_id','=','tags.id')
+            ->select('tags.*',DB::raw('COUNT(post_tag.post_id) as posts_count'))
+            ->leftJoin('post_tag','post_tag.tag_id','=','tags.id')
             ->groupBy('tags.id')
             ->paginate(50);
 

--- a/app/Post.php
+++ b/app/Post.php
@@ -9,7 +9,7 @@ class Post extends Model
     protected $guarded = [];
 
     public function tags(){
-        return $this->belongsToMany(Tag::class,'posts_tags');
+        return $this->belongsToMany(Tag::class,'post_tag');
     }
 
     public function user(){

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -9,6 +9,6 @@ class Tag extends Model
     protected $guarded = [];
 
     public function posts(){
-        return $this->belongsToMany(Post::class,'post_tag');
+        return $this->belongsToMany(Post::class);
     }
 }

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -9,6 +9,6 @@ class Tag extends Model
     protected $guarded = [];
 
     public function posts(){
-        return $this->belongsToMany(Post::class,'posts_tags');
+        return $this->belongsToMany(Post::class,'post_tag');
     }
 }

--- a/database/migrations/2020_03_02_202054_create_post_tag_table.php
+++ b/database/migrations/2020_03_02_202054_create_post_tag_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTagsTable extends Migration
+class CreatePostTagTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,9 +13,14 @@ class CreateTagsTable extends Migration
      */
     public function up()
     {
-        Schema::create('tags', function (Blueprint $table) {
+        Schema::create('post_tag', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('name');
+            $table->unsignedBigInteger('post_id');
+            $table->unsignedBigInteger('tag_id');
+
+            $table->foreign('post_id')->references('id')->on('posts');
+            $table->foreign('tag_id')->references('id')->on('tags');
+
             $table->timestamps();
         });
     }
@@ -27,6 +32,6 @@ class CreateTagsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('tags');
+        Schema::dropIfExists('post_tag');
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,6 @@
 <?php
 
 Route::get('/',function(){ return redirect('/posts'); });
-Route::get('/posts','PostsController@index');
-Route::get('/categories','CategoriesController@index');
-Route::get('/tags','TagsController@index');
+Route::get('/posts','PostController@index');
+Route::get('/categories','CategoryController@index');
+Route::get('/tags','TagController@index');


### PR DESCRIPTION
- Change many to many table posts_tags to post_tag depend on laravel documentation.
- Make it in separate migration file that able to rollback.
- Change naming of controllers from plural to singular depend on best practice.  